### PR TITLE
Add challonge match display and assignment

### DIFF
--- a/public/javascripts/tournament.js
+++ b/public/javascripts/tournament.js
@@ -95,9 +95,13 @@ function updateSetupsList(setupsList) {
 		if (setup.status === 'Assigned') {
 			var match = matchDict[setup.matchId];
 			if (match) {
-				var player1 = playerDict[match.player1_id];
-				var player2 = playerDict[match.player2_id];
-				$setup.append('<div>' + player1 + ' vs ' + player2 + '</div>');
+				if (match.state === 'open') {
+					var player1 = playerDict[match.player1_id];
+					var player2 = playerDict[match.player2_id];
+					$setup.append('<div>' + player1 + ' vs ' + player2 + '</div>');
+				} else {
+					tournamentSocket.emit('open setup', i);
+				}
 			}
 			$setup.append('<a href="" class="reassign-setup">Reassign</a>');
 		}
@@ -160,7 +164,6 @@ $(function() {
 	});
 
 	tournamentSocket.on('tournament info', function(info) {
-		var $setupsList;
 		var $challongeUrl;
 		var availableMatchList;
 		if (!info) {

--- a/public/javascripts/tournament.js
+++ b/public/javascripts/tournament.js
@@ -125,12 +125,12 @@ $(function() {
 		tournamentSocket.emit('open setup', setupIndex);
 	});
 
-	$('#save-challonge-url').click(function() {
+	$('#save-challonge-url').on('click', function() {
 		var url = $('#challonge-url').val();
 		tournamentSocket.emit('save challonge url', url);
 	});
 
-	$('#add-setup').click(function() {
+	$('#add-setup').on('click', function() {
 		tournamentSocket.emit('add setup');
 	});
 

--- a/public/javascripts/tournament.js
+++ b/public/javascripts/tournament.js
@@ -1,4 +1,6 @@
-var socket = io('/tournament');
+var tournamentSocket = io('/tournament');
+var challongeSocket = io('/challonge');
+var setups = [];
 
 function getLastPartOfUrl() {
 	var partArray = window.location.href.split('/');
@@ -9,33 +11,114 @@ function getLastPartOfUrl() {
 	return lastPart;
 }
 
+function getAvailableMatches(challongeInfo) {
+    var availableMatches = [];
+    challongeInfo.matches.forEach(function(match) {
+        if (match.match.state === 'open') {
+            availableMatches.push(match);
+        }
+    });
+    return availableMatches;
+}
+
+function getPlayerDictionary(challongeInfo) {
+    var playerDict = {};
+
+    challongeInfo.participants.forEach(function(player) {
+        playerDict[player.participant.id] = player.participant.name || player.participant.username;
+    });
+
+    return playerDict;
+}
+
+function buildSetupSelector(setupList) {
+	var $selector = $('<select class="setup-selector"><option value="" disabled selected style="display:none;"></option></select>');
+	for (var i = 0; i < setupList.length; i++) {
+		if (!setupList[i].status) {
+			$selector.append('<option value=' + (i + 1) + '>' + (i + 1) + '</option>');
+		}
+	}
+	return $selector;
+}
+
+function updateMatchList(availableMatches, players) {
+	var $matchList = $('#matches-tbody');
+	var $setupSelector = buildSetupSelector(setups);
+	$matchList.empty();
+	availableMatches.forEach(function(match) {
+		var tableRow = [];
+		var player1Id = match.match.player1_id;
+		var player2Id = match.match.player2_id;
+		var player1 = players[player1Id];
+		var player2 = players[player2Id];
+		tableRow.push('<tr class="available-match-row" data-id="' + match.match.id + '"><td>');
+		tableRow.push(player1 + ' vs. ' + player2);
+		tableRow.push('</td><td>');
+		tableRow.push('<div class="setup-selector"></div>');
+		tableRow.push('</td></tr>');
+		$matchList.append(tableRow.join(''));
+	});
+	$('.setup-selector').append($setupSelector.clone());
+}
+
 $(function() {
+	$(document).on('change', '.setup-selector', function() {
+		var setup = $(this).val();
+
+	});
+
 	$('#save-challonge-url').click(function() {
 		var url = $('#challonge-url').val();
-		socket.emit('save challonge url', url);
+		tournamentSocket.emit('save challonge url', url);
 	});
 
 	$('#add-setup').click(function() {
-		socket.emit('add setup');
+		tournamentSocket.emit('add setup');
 	});
 
-	socket.on('request room', function() {
+	challongeSocket.on('request room', function() {
+		var challongeUrl = $('#challonge-url').val();
+		tournamentSocket.emit('join room', challongeUrl);
+	});
+
+	challongeSocket.on('tournament info', function(info) {
+		var availableMatches = getAvailableMatches(info);
+		var players = getPlayerDictionary(info);
+
+		updateMatchList(availableMatches, players);
+		$('.available-match-count').text(availableMatches.length);
+	});
+
+	tournamentSocket.on('request room', function() {
 		var room = getLastPartOfUrl();
-		socket.emit('join room', room);
+		tournamentSocket.emit('join room', room);
 	});
 
-	socket.on('tournament info', function(info) {
+	tournamentSocket.on('tournament info', function(info) {
+		var $setupsList;
+		var $challongeUrl;
 		if (!info) {
 			return;
 		}
 		if (info.challongeUrl) {
-			$('#challonge-url').val(info.challongeUrl);
+			$challongeUrl = $('#challonge-url');
+			if ($challongeUrl.val() !== info.challongeUrl) {
+				$challongeUrl.val(info.challongeUrl);
+				challongeSocket.emit('join room', info.challongeUrl);
+			}
 		}
-		var $setupsList = $('#setups-list');
+		$setupsList = $('#setups-list');
 		$setupsList.empty();
 		if (info.setups) {
+			setups = info.setups;
 			for (var i = 0; i < info.setups.length; i++) {
-				$setupsList.append('<li>' + (i + 1) + '</li>');
+				var setup = info.setups[i];
+				var $setup = $('<li></li>');
+				$setup.append('<div class="setup-id">' + (i + 1) + '</div>');
+				if (!setup.status) {
+					$setup.append('<div class="available-matches"></div>');
+				}
+				$setupsList.append($setup);
 			}
 		}
 	});

--- a/services/challonge.js
+++ b/services/challonge.js
@@ -1,0 +1,75 @@
+var config = require('../config');
+var request = require('request');
+var redis = require('redis');
+var pmx = require('pmx');
+
+var client = redis.createClient();
+
+var challongeExpireSeconds = 10;
+var challongeApiRoot = 'https://api.challonge.com/v1';
+var challongeBaseKey = 'challonge-';
+
+var ChallongeService = function ChallongeService() { };
+
+function getChallongeTournamentKey(challongeHash) {
+    return challongeBaseKey + 'tournament-' + challongeHash;
+}
+
+ChallongeService.prototype.getChallongeHash = function getChallongeHash(challongeUrl) {
+    var tourneyHash = challongeUrl.substring(challongeUrl.lastIndexOf('/') + 1).trim();
+    var orgHash;
+
+    // If tournament belongs to an organization,
+    // it must be specified in the request
+    if (challongeUrl.split('.').length - 1 > 1) {
+        orgHash = challongeUrl.substring(challongeUrl.lastIndexOf('http://') + 7, challongeUrl.indexOf('.'));
+        return orgHash + '-' + tourneyHash;
+    }
+
+    // Standard tournament
+    return tourneyHash;
+};
+
+ChallongeService.prototype.getTournament = function getTournament(tournamentUrl, callback) {
+    var challongeHash = this.getChallongeHash(tournamentUrl);
+    var challongeKey = getChallongeTournamentKey(challongeHash);
+    var options;
+    client.get(challongeKey, function(err, reply) {
+        if (err) {
+            console.error(err);
+        } else if (reply) {
+            callback(JSON.parse(reply));
+        }
+
+        options = {
+            url: challongeApiRoot + '/tournaments/' + challongeHash + '.json?include_matches=1&include_participants=1',
+            method: 'GET',
+            headers: {
+                // Basic Auth must be encoded or request will be denied
+                'Authorization': 'Basic ' + new Buffer(config.challongeDevUsername + ':' + config.challongeApiKey).toString('base64')
+            }
+        };
+
+        request(options, function(error, response, body) {
+            var challongeTournament;
+            var errorMessage;
+            if (!error && response && response.statusCode === 200) {
+                try {
+                    challongeTournament = JSON.parse(body).tournament;
+                    client.setex(challongeKey, challongeExpireSeconds, JSON.stringify(challongeTournament));
+                    callback(challongeTournament);
+                } catch (e) {
+                    errorMessage = 'Challonge response could not be parsed: ' + body;
+                    console.error(errorMessage);
+                    pmx.notify(errorMessage);
+                }
+            } else {
+                errorMessage = 'Error: ' + error + ' Response: ' + response;
+                console.error(errorMessage);
+                pmx.notify(errorMessage);
+            }
+        });
+    });
+};
+
+module.exports = new ChallongeService();

--- a/services/challonge.js
+++ b/services/challonge.js
@@ -5,7 +5,7 @@ var pmx = require('pmx');
 
 var client = redis.createClient();
 
-var challongeExpireSeconds = 10;
+var challongeExpireSeconds = 8;
 var challongeApiRoot = 'https://api.challonge.com/v1';
 var challongeBaseKey = 'challonge-';
 

--- a/services/tournament.js
+++ b/services/tournament.js
@@ -29,13 +29,17 @@ TournamentService.prototype.getTournaments = function(callback) {
 TournamentService.prototype.addTournament = function(tournamentName, callback) {
 	client.get(tournamentList, function(err, reply) {
 		var tournaments = JSON.parse(reply);
+		var defaultTournament = {
+			challongeUrl: null,
+			setups: [],
+		};
 		tournaments[tournamentName] = true;
 		client.set(tournamentList, JSON.stringify(tournaments), function() {
 			if (callback) {
 				callback(tournaments);
 			}
 		});
-		client.set(getTournamentInfoKey(tournamentName), JSON.stringify({}));
+		client.set(getTournamentInfoKey(tournamentName), JSON.stringify(defaultTournament));
 	});
 };
 
@@ -91,7 +95,25 @@ TournamentService.prototype.addSetup = function(tournamentName, callback) {
 	_this.getTournamentInfo(tournamentName, function(info) {
 		var newInfo = info === null ? {} : info;
 		newInfo.setups = newInfo.setups || [];
-		newInfo.setups.push({});
+		newInfo.setups.push({
+			status: 'Open'
+		});
+		_this.setTournamentInfo(tournamentName, newInfo, function() {
+			if (callback) {
+				callback(newInfo);
+			}
+		});
+	});
+};
+
+TournamentService.prototype.assignSetup = function(tournamentName, setupId, matchId, callback) {
+	var _this = this;
+	_this.getTournamentInfo(tournamentName, function(info) {
+		var newInfo = info === null ? {} : info;
+		if (newInfo.setups && newInfo.setups[setupId]) {
+			newInfo.setups[setupId].status = 'Assigned';
+			newInfo.setups[setupId].matchId = matchId;
+		}
 		_this.setTournamentInfo(tournamentName, newInfo, function() {
 			if (callback) {
 				callback(newInfo);

--- a/services/tournament.js
+++ b/services/tournament.js
@@ -122,4 +122,20 @@ TournamentService.prototype.assignSetup = function(tournamentName, setupId, matc
 	});
 };
 
+TournamentService.prototype.openSetup = function(tournamentName, setupId, callback) {
+	var _this = this;
+	_this.getTournamentInfo(tournamentName, function(info) {
+		var newInfo = info === null ? {} : info;
+		if (newInfo.setups && newInfo.setups[setupId]) {
+			newInfo.setups[setupId].status = 'Open';
+			newInfo.setups[setupId].matchId = null;
+		}
+		_this.setTournamentInfo(tournamentName, newInfo, function() {
+			if (callback) {
+				callback(newInfo);
+			}
+		});
+	});
+};
+
 module.exports = new TournamentService();

--- a/services/tournament.js
+++ b/services/tournament.js
@@ -17,6 +17,10 @@ function getTournamentInfoKey(tournamentName) {
 	return tournamentBaseKey + 'info-' + tournamentName;
 }
 
+function getTournamentChallongeKey(tournamentName) {
+	return tournamentBaseKey + 'challonge-' + tournamentName;
+}
+
 TournamentService.prototype.getTournaments = function(callback) {
 	client.get(tournamentList, function(err, reply) {
 		var tournaments = JSON.parse(reply);
@@ -30,7 +34,6 @@ TournamentService.prototype.addTournament = function(tournamentName, callback) {
 	client.get(tournamentList, function(err, reply) {
 		var tournaments = JSON.parse(reply);
 		var defaultTournament = {
-			challongeUrl: null,
 			setups: [],
 		};
 		tournaments[tournamentName] = true;
@@ -77,16 +80,23 @@ TournamentService.prototype.setTournamentInfo = function(tournamentName, tournam
 	});
 };
 
+TournamentService.prototype.getChallongeUrl = function(tournamentName, callback) {
+	client.get(getTournamentChallongeKey(tournamentName), function(err, reply) {
+		if (err) {
+			console.log(err);
+		} else if (callback) {
+			return callback(reply);
+		}
+	});
+};
+
 TournamentService.prototype.setChallongeUrl = function(tournamentName, url, callback) {
-	var _this = this;
-	_this.getTournamentInfo(tournamentName, function(info) {
-		var newInfo = info === null ? {} : info;
-		newInfo.challongeUrl = url;
-		_this.setTournamentInfo(tournamentName, newInfo, function() {
-			if (callback) {
-				callback(newInfo);
-			}
-		});
+	client.set(getTournamentChallongeKey(tournamentName), url, function(err) {
+		if (err) {
+			console.log(err);
+		} else {
+			callback(url);
+		}
 	});
 };
 

--- a/services/tournament.js
+++ b/services/tournament.js
@@ -6,7 +6,7 @@ var tournamentList = tournamentBaseKey + 'list';
 
 var TournamentService = function TournamentService() {
 	var emptyArray = JSON.stringify({});
-    client.set(tournamentList, emptyArray, 'NX', function(err) {
+    client.setnx(tournamentList, emptyArray, function(err) {
         if (err) {
             console.log(err);
         }

--- a/sockets/challonge.js
+++ b/sockets/challonge.js
@@ -1,223 +1,36 @@
-var config = require('../config');
-var request = require('request');
-var redis = require('redis');
-var pmx = require('pmx');
-
-var client = redis.createClient();
-var redisKey = 'web-overlay-challonge';
+var challongeService = require('../services/challonge');
 
 module.exports = function(io) {
-    var challongeData = {};
-    var challongePollFrequency = 10000;
-    var connectedSockets = 0;
-    var challongeApiRoot = 'https://api.challonge.com/v1';
-    var challongeHash = null;
-    var matches = [];
-    var players = [];
-    var top8Round = 0;
-    //Used to check for updates
-    var availableMatchesCache = [];
-    var top8cache = {};
-    var timeout = null;
-
-    // Load existing challonge data
-    client.get(redisKey, function (err, reply) {
-        if (err) {
-            console.log(err);
-        } else if (reply) {
-            challongeData = JSON.parse(reply);
-            challongeHash = challongeData.challongeApiHash;
-        }
-    });
-
     var challongeIO = io.of('/challonge');
 
     challongeIO.on('connection', function(socket) {
         // Log the new connection
         console.log('challonge user connected: ' + socket.handshake.address + ' -> ' + socket.request.headers.referer);
 
-        socket.emit('update challonge', challongeData);
-        socket.emit('update challonge top8', top8cache);
-        connectedSockets++;
+        challongeIO.to(socket.id).emit('request room');
 
-        // if we go from 0 to 1 socket, start polling again
-        pollChallonge();
+        socket.on('join room', function(room) {
+            console.log('Joining room: ' + room);
+            if (socket.rooms.length > 2) {
+                console.error('Challonge socket is in multiple rooms: ' + socket.rooms);
+            }
+            socket.join(room, function() {
+                challongeService.getTournament(room, function(info) {
+                    challongeIO.to(socket.id).emit('tournament info', info);
+                });
+            });
+        });
+
+        socket.on('request tournament', function() {
+            var tournament = socket.rooms[socket.rooms.length - 1];
+            console.log('Requesting tournament for ' + tournament);
+            challongeService.getTournament(tournament, function(info) {
+                challongeIO.to(tournament).emit('tournament info', info);
+            });
+        });
 
         socket.on('disconnect', function() {
             console.log('challonge user disconnected: ' + socket.handshake.address);
-            connectedSockets--;
-            if (connectedSockets <= 0) {
-                connectedSockets = 0;
-                clearTimeout(timeout);
-            }
         });
-
-        socket.on('update challonge', function(msg) {
-            var urlChanged = msg.challongeUrl !== challongeData.challongeUrl;
-            challongeData = msg;
-            if (challongeData.challongeUrl) {
-                if (!challongeHash || urlChanged) {
-                    availableMatchesCache = [];
-                    challongeHash = createChallongeHash(challongeData.challongeUrl);
-                    challongeData.challongeApiHash = challongeHash;
-                    clearTimeout(timeout);
-                    pollChallonge();
-                    client.set(redisKey, JSON.stringify(challongeData));
-                }
-            }
-        });
-
-        socket.on('clear bracket', function() {
-            clearBracket();
-        });
-
-        function pollChallonge() {
-            if (connectedSockets > 0 && challongeHash) {
-                console.log('Polling challonge for updates...');
-                fetchChallongeData();
-                timeout = setTimeout(pollChallonge, challongePollFrequency);
-            }
-        }
-
-        function sendChallongeUpdate() {
-            challongeData.upcomingMatches = getUpcomingMatches();
-            if (checkForMatchUpdates()) {
-                availableMatchesCache = challongeData.upcomingMatches;
-                challongeData.players = getPlayerDictionary();
-                console.log('Sending challonge update');
-                challongeIO.emit('update challonge', challongeData);
-            }
-            client.set(redisKey, JSON.stringify(challongeData));
-        }
-
-        function sendTop8Update() {
-            var top8 = getTop8();
-            if (JSON.stringify(top8) !== JSON.stringify(top8cache)) {
-                challongeIO.emit('update challonge top8', top8);
-                top8cache = top8;
-            }
-        }
-
-        function getTop8() {
-            var top8Object = {
-                matches: [],
-                participants: [],
-                top8Round: top8Round
-            };
-            var participantIdList = [];
-            var i;
-            var match;
-            var player;
-
-            for (i = 0; i < matches.length; i++) {
-                match = matches[i].match;
-                if (match.round && (match.round >= top8Round || match.round <= -top8Round)) {
-                                    console.log(match);
-                    top8Object.matches.push(match);
-                }
-                participantIdList.push(match.player1_id);
-                participantIdList.push(match.player2_id);
-            }
-            for (i = 0; i < players.length; i++) {
-                player = players[i].participant;
-                if (participantIdList.indexOf(player['id']) >= 0) {
-                    top8Object.participants.push(player);
-                }
-            }
-
-            return top8Object;
-        }
-
-        function fetchChallongeData() {
-            var headers = {
-                //Basic Auth must be encoded or request will be denied
-                'Authorization': 'Basic ' + new Buffer(config.challongeDevUsername + ':' + config.challongeApiKey).toString('base64')
-            };
-            var options = {
-                url: challongeApiRoot + '/tournaments/' + challongeHash + '.json?include_matches=1&include_participants=1',
-                method: 'GET',
-                headers: headers
-            };
-
-            console.log('Requesting tournament data for ' + challongeData.challongeUrl);
-
-            request(options, function (error, response, body) {
-                if (!error && response.statusCode === 200) {
-                    try {
-                        var challongeResponse = JSON.parse(body);
-                        top8Round = Math.ceil(Math.log(challongeResponse.tournament.participants_count / 4) / Math.log(2)) + 1;
-                        matches = challongeResponse.tournament.matches;
-                        players = challongeResponse.tournament.participants;
-                        sendChallongeUpdate();
-                        sendTop8Update();
-                    } catch (e) {
-                        var errorMessage = 'Challonge response could not be parsed: ' + body;
-                        console.log(errorMessage);
-                        pmx.notify(errorMessage);
-                    }
-                }
-            });
-        }
-
-        function getUpcomingMatches() {
-            var upcomingMatches = [];
-            matches.forEach(function(match){
-                if (match.match.state === 'open') {
-                    upcomingMatches.push(match);
-                }
-            });
-
-            return upcomingMatches;
-        }
-
-        function getPlayerDictionary() {
-            var playerDict = {};
-
-            players.forEach(function(player){
-                playerDict[player.participant.id] = player.participant.name || player.participant.username;
-            });
-
-            return playerDict;
-        }
-
-        function createChallongeHash(challongeUrl) {
-            var tourneyHash = challongeUrl.substring(challongeUrl.lastIndexOf('/') + 1).trim();
-
-            //If tournament belongs to an organization,
-            //it must be specified in the request
-            if (challongeUrl.split('.').length - 1 > 1) {
-                var orgHash = challongeUrl.substring(challongeUrl.lastIndexOf('http://') + 7, challongeUrl.indexOf('.'));
-                challongeHash = orgHash + '-' + tourneyHash;
-                return challongeHash;
-            }
-
-            //Standard tournament
-            challongeHash = tourneyHash;
-            return challongeHash;
-        }
-
-        function checkForMatchUpdates() {
-            if (challongeData.upcomingMatches.length !== availableMatchesCache.length) {
-                return true;
-            }
-            for (var i = 0; i < availableMatchesCache.length; i++) {
-                if (availableMatchesCache[i].match.id !== challongeData.upcomingMatches[i].match.id) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        function clearBracket() {
-            console.log('Clearing challonge data');
-            challongeHash = null;
-            challongeData = {};
-            matches = [];
-            players = [];
-            availableMatchesCache = [];
-            clearTimeout(timeout);
-            socket.emit('update challonge', challongeData);
-            client.set(redisKey, JSON.stringify(challongeData));
-        }
     });
 };

--- a/sockets/challonge.js
+++ b/sockets/challonge.js
@@ -21,7 +21,7 @@ module.exports = function(io) {
             });
         });
 
-        socket.on('request tournament', function() {
+        socket.on('request tournament info', function() {
             var tournament = socket.rooms[socket.rooms.length - 1];
             console.log('Requesting tournament for ' + tournament);
             challongeService.getTournament(tournament, function(info) {

--- a/sockets/challonge.js
+++ b/sockets/challonge.js
@@ -7,16 +7,34 @@ module.exports = function(io) {
         // Log the new connection
         console.log('challonge user connected: ' + socket.handshake.address + ' -> ' + socket.request.headers.referer);
 
-        challongeIO.to(socket.id).emit('request room');
-
         socket.on('join room', function(room) {
             console.log('Joining challonge room: ' + room);
             if (socket.rooms.length > 2) {
                 console.error('Challonge socket is in multiple rooms: ' + socket.rooms);
             }
             socket.join(room, function() {
+                challongeIO.to(socket.id).emit('room joined', room);
                 challongeService.getTournament(room, function(info) {
                     challongeIO.to(socket.id).emit('tournament info', info);
+                });
+            });
+        });
+
+        socket.on('change room', function(roomData) {
+            if (!roomData || !roomData.oldRoom || !roomData.newRoom) {
+                return;
+            }
+            socket.leave(roomData.oldRoom, function() {
+                console.log('Leaving challonge room: ' + roomData.oldRoom);
+                socket.join(roomData.newRoom, function() {
+                    console.log('Joining challonge room: ' + roomData.newRoom);
+                    if (socket.rooms.length > 2) {
+                        console.error('Challonge socket is in multiple rooms: ' + socket.rooms);
+                    }
+                    challongeIO.to(socket.id).emit('room joined', roomData.newRoom);
+                    challongeService.getTournament(roomData.newRoom, function(info) {
+                        challongeIO.to(socket.id).emit('tournament info', info);
+                    });
                 });
             });
         });

--- a/sockets/challonge.js
+++ b/sockets/challonge.js
@@ -10,7 +10,7 @@ module.exports = function(io) {
         challongeIO.to(socket.id).emit('request room');
 
         socket.on('join room', function(room) {
-            console.log('Joining room: ' + room);
+            console.log('Joining challonge room: ' + room);
             if (socket.rooms.length > 2) {
                 console.error('Challonge socket is in multiple rooms: ' + socket.rooms);
             }

--- a/sockets/tournament.js
+++ b/sockets/tournament.js
@@ -10,6 +10,9 @@ module.exports = function(io) {
 		tournamentIo.to(socket.id).emit('request room');
 
 		socket.on('join room', function(room) {
+            if (socket.rooms.length > 2) {
+                console.error('Tournament socket is in multiple rooms: ' + socket.rooms);
+            }
 			socket.join(room, function() {
 				tournamentService.getTournamentInfo(room, function(info) {
 					tournamentIo.to(socket.id).emit('tournament info', info);

--- a/sockets/tournament.js
+++ b/sockets/tournament.js
@@ -15,6 +15,8 @@ module.exports = function(io) {
             }
 			socket.join(room, function() {
 				tournamentService.getTournamentInfo(room, function(info) {
+					console.log('joining and emitting');
+					console.log(info);
 					tournamentIo.to(socket.id).emit('tournament info', info);
 				});
 			});
@@ -23,6 +25,7 @@ module.exports = function(io) {
 		socket.on('save challonge url', function(url) {
 			var tournament = socket.rooms[socket.rooms.length - 1];
 			tournamentService.setChallongeUrl(tournament, url, function(info) {
+				console.log('saving challonge url and emitting');
 				tournamentIo.to(tournament).emit('tournament info', info);
 			});
 		});
@@ -30,6 +33,15 @@ module.exports = function(io) {
 		socket.on('add setup', function() {
 			var tournament = socket.rooms[socket.rooms.length - 1];
 			tournamentService.addSetup(tournament, function(info) {
+				console.log('adding setup and emitting');
+				tournamentIo.to(tournament).emit('tournament info', info);
+			});
+		});
+
+		socket.on('assign setup', function(setupId, matchId) {
+			var tournament = socket.rooms[socket.rooms.length - 1];
+			tournamentService.assignSetup(tournament, setupId, matchId, function(info) {
+				console.log('assigning setup and emitting');
 				tournamentIo.to(tournament).emit('tournament info', info);
 			});
 		});

--- a/sockets/tournament.js
+++ b/sockets/tournament.js
@@ -45,5 +45,13 @@ module.exports = function(io) {
 				tournamentIo.to(tournament).emit('tournament info', info);
 			});
 		});
+
+		socket.on('open setup', function(setupId) {
+			var tournament = socket.rooms[socket.rooms.length - 1];
+			tournamentService.openSetup(tournament, setupId, function(info) {
+				console.log('opening setup and emitting');
+				tournamentIo.to(tournament).emit('tournament info', info);
+			});
+		});
 	});
 };

--- a/views/tournament.hbs
+++ b/views/tournament.hbs
@@ -8,7 +8,17 @@
 <ul id="setups-list"></ul>
 <button id="add-setup">Add Setup</button>
 
+<div><span class="available-match-count">-</span> available matches</div>
 <div>Matches</div>
+<table>
+	<thead>
+	    <tr>
+	      <th>Match</th>
+	      <th>Setup</th>
+	    </tr>
+	</thead>
+	<tbody id="matches-tbody"></tbody>
+</table>
 
 <link rel='stylesheet' href='/stylesheets/admin.css' />
 <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>


### PR DESCRIPTION
Display a list of open challonge matches, and assign them to setups. They will unassign from setups when their challonge state changes from 'open'.

Fixes #1 
